### PR TITLE
increase the request timeout to 10s

### DIFF
--- a/lib/admin-client.js
+++ b/lib/admin-client.js
@@ -120,6 +120,7 @@ AdminClient.prototype.requestV2 = function requestV2(host, endpoint, head, body,
             hasNoParent: true,
             retryLimit: 1,
             trace: false,
+            timeout: 10000,
             headers: {
                 'as': 'raw',
                 'cn': 'ringpop'


### PR DESCRIPTION
r @jwolski @benfleis 

The default timeout is 100ms, which won't work on production hosts.