### PR TITLE
Feature partitions command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/*
 npm-debug.log
 *.swp
+hosts.json

--- a/commands.js
+++ b/commands.js
@@ -31,10 +31,10 @@ function StatusCommand(tchannelV1, coordinator) {
     this.coordinator = coordinator;
 }
 
-function PartitionCommand(tchannelV1, coordinatorOrFile, quite) {
+function PartitionCommand(tchannelV1, coordinatorOrFile, quiet) {
     this.useTChannelV1 = tchannelV1;
     this.coordinatorOrFile = coordinatorOrFile;
-    this.quite = quite;
+    this.quiet = quiet;
 }
 
 module.exports = {

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -159,6 +159,7 @@ Cluster.prototype.fetchStats = function fetchStats(callback) {
 
             statsObj.membershipChecksum = stats.membership.checksum;
             statsObj.members = stats.membership.members;
+            statsObj.node = memberAddr;
 
             // queue this members for query
             queueMembers(

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -80,6 +80,32 @@ Cluster.prototype.getPartitionCount = function getPartitionCount() {
     return Object.keys(this.partitions).length;
 };
 
+Cluster.prototype.getSeedList = function getSeedList(callback) {
+    var self = this;
+    // figure out if the coordinator is a file
+    fs.exists(self.coordAddr, function (exists) {
+        if (exists) {
+            // treat the coordinator as a bootstrap file
+            fs.readFile(self.coordAddr, function (err, body) {
+                if (err) {
+                    return callback(err);
+                }
+
+                try {
+                    body = JSON.parse(body);
+                } catch (e) {
+                    return callback(e);
+                }
+
+                // seed the list with the hosts in the bootstrap file
+                return callback(null, body);
+            });
+        } else {
+            return callback(null, [self.coordAddr]);
+        }
+    });
+};
+
 Cluster.prototype.fetchStats = function fetchStats(callback) {
     var self = this;
 
@@ -89,56 +115,88 @@ Cluster.prototype.fetchStats = function fetchStats(callback) {
     this.lastFetchTime = new Date().toISOString();
     var downloadTime = Date.now();
 
-    this.adminClient.stats(this.coordAddr, function onSend(err, stats) {
+    var foundMembers = {};
+    var allStats = [];
+    var fetchQueue = async.queue(mapMember, 5);
+
+    fetchQueue.drain = function () {
+        onComplete(null, allStats);
+    };
+
+    this.getSeedList(function (err, seeds) {
         if (err) {
-            callback(err);
-            return;
+            return callback(err);
         }
-
-        if (!stats) {
-            callback(new Error('stats could not be gathered'));
-            return;
-        }
-
-        if (!stats.membership) {
-            callback(new Error('stats did not contain membership'));
-            return;
-        }
-
-        if (!stats.membership.members) {
-            callback(new Error('membership did not contain members'));
-            return;
-        }
-
-        async.mapLimit(stats.membership.members, self.fetchLimit, mapMember, onComplete);
-
-        function mapMember(member, next) {
-            self.adminClient.stats(member.address, function(err, stats) {
-                var statsObj = new Stats();
-                statsObj.address = member.address;
-
-                if (err) {
-                    next(null, statsObj);
-                    return;
-                }
-
-                statsObj.membershipChecksum = stats.membership.checksum;
-                statsObj.members = stats.membership.members;
-
-                next(null, statsObj);
-            });
-        }
-
-        function onComplete(err, allStats) {
-            self.lastDownloadTime = Date.now() - downloadTime;
-            self.allStats = allStats;
-            self.allStats.forEach(function eachStats(stats) {
-                self.parseStats(stats);
-            });
-
-            callback();
-        }
+        queueMembers(seeds);
     });
+
+    return;
+
+    function mapMember(memberAddr, next) {
+        self.adminClient.stats(memberAddr, function(err, stats) {
+            var statsObj = new Stats();
+            statsObj.address = memberAddr;
+
+            if (err) {
+                next(null, statsObj);
+                return;
+            }
+
+            if (!stats) {
+                callback(new Error('stats could not be gathered'));
+                return;
+            }
+
+            if (!stats.membership) {
+                callback(new Error('stats did not contain membership'));
+                return;
+            }
+
+            if (!stats.membership.members) {
+                callback(new Error('membership did not contain members'));
+                return;
+            }
+
+            statsObj.membershipChecksum = stats.membership.checksum;
+            statsObj.members = stats.membership.members;
+
+            // queue this members for query
+            queueMembers(
+                stats.membership.members.map(
+                    function getAddressFromMember(member) {
+                        return member.address;
+                    }
+                )
+            );
+
+            next(null, statsObj);
+        });
+    }
+
+    function onComplete(err, allStats) {
+        self.lastDownloadTime = Date.now() - downloadTime;
+        self.allStats = allStats;
+        self.allStats.forEach(function eachStats(stats) {
+            self.parseStats(stats);
+        });
+
+        callback();
+    }
+
+    function queueMembers(membersAddr) {
+        membersAddr.forEach(function (memberAddr) {
+            if (memberAddr in foundMembers) {
+                return;
+            }
+
+            foundMembers[memberAddr] = true;
+            fetchQueue.push(memberAddr, function (err, stats) {
+                if (err) return;
+
+                allStats.push(stats);
+            });
+        });
+    }
 };
 
 Cluster.prototype.lookup = function lookup(key, callback) {

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -192,7 +192,10 @@ Cluster.prototype.fetchStats = function fetchStats(callback) {
 
             foundMembers[memberAddr] = true;
             fetchQueue.push(memberAddr, function onStatsFetched(err, stats) {
-                if (err) return;
+                if (err) {
+                    console.error('Error while fetching node stats:', err);
+                    return;
+                }
 
                 allStats.push(stats);
             });

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -191,7 +191,7 @@ Cluster.prototype.fetchStats = function fetchStats(callback) {
             }
 
             foundMembers[memberAddr] = true;
-            fetchQueue.push(memberAddr, function (err, stats) {
+            fetchQueue.push(memberAddr, function onStatsFetched(err, stats) {
                 if (err) return;
 
                 allStats.push(stats);

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -23,6 +23,7 @@ function Stats() {
     this.address = null;
     this.membershipChecksum = null;
     this.members = null;
+    this.node = null;
 }
 
 module.exports = Stats;

--- a/parser.js
+++ b/parser.js
@@ -61,7 +61,7 @@ function parsePartitionCommand() {
     program
         .description('Show partition information of a ring')
         .option('--tchannel-v1')
-        .option('-q, --quite', 'Don\'t print headers')
+        .option('-q, --quiet', 'Don\'t print headers')
         .usage('[options] <coordinatorOrFile>');
     program.parse(process.argv);
     assertPositionArg(program, 0, 'coordinatorOrFile');
@@ -69,7 +69,7 @@ function parsePartitionCommand() {
     return new commands.PartitionCommand(
         program.tchannelV1,
         program.args[0],
-        program.quite
+        program.quiet
     );
 }
 

--- a/parser.js
+++ b/parser.js
@@ -59,7 +59,7 @@ function parseStatusCommand() {
 
 function parsePartitionCommand() {
     program
-        .description('Show partition information of ring')
+        .description('Show partition information of a ring')
         .option('--tchannel-v1')
         .option('-q, --quite', 'Don\'t print headers')
         .usage('[options] <coordinatorOrFile>');

--- a/parser.js
+++ b/parser.js
@@ -57,7 +57,24 @@ function parseStatusCommand() {
     return new commands.StatusCommand(program.tchannelV1, program.args[0]);
 }
 
+function parsePartitionCommand() {
+    program
+        .description('Show partition information of ring')
+        .option('--tchannel-v1')
+        .option('-q, --quite', 'Don\'t print headers')
+        .usage('[options] <coordinatorOrFile>');
+    program.parse(process.argv);
+    assertPositionArg(program, 0, 'coordinatorOrFile');
+
+    return new commands.PartitionCommand(
+        program.tchannelV1,
+        program.args[0],
+        program.quite
+    );
+}
+
 module.exports = {
     parseReuseCommand: parseReuseCommand,
-    parseStatusCommand: parseStatusCommand
+    parseStatusCommand: parseStatusCommand,
+    parsePartitionCommand: parsePartitionCommand
 };

--- a/partitions.js
+++ b/partitions.js
@@ -41,7 +41,7 @@ function main() {
         var partitions = clusterManager.getPartitions();
 
         var headers = [];
-        if (!command.quite) {
+        if (!command.quiet) {
             headers = [
                 'Checksum',
                 '# Nodes',

--- a/ringpop-admin.js
+++ b/ringpop-admin.js
@@ -36,6 +36,7 @@ function main() {
         .command('lookup', 'Lookup a key in the ring')
         .command('join', 'Makes node (re)join the cluster')
         .command('status', 'Status of members in ring')
+        .command('partitions', 'Show partition information of a ring')
         .command('top', 'General membership information')
         .parse(process.argv);
 }


### PR DESCRIPTION
There are two things in the PR (bad me, and if we want them separate of each other I will split it).

1. Besides working with a single `coordinator` for running the commands you can now choose to pass in a bootstrap file as a seed list for your cluster. This way we can find split brain partitions as well. This works on everything but `lookup`. It also uses an async queue to keep fanning out as it finds new nodes in membership of other nodes.

2. a new command that prints out all partitions it find as follows:
```
$ ./partitions.js ./hosts.json
 Checksum     # Nodes   Sample Host
 4140474601   10        10.32.163.67:3000
```
Naturally if there are more partitions you will see them on separate lines.

/cc @uber/ringpop 