### PR TITLE
Tidy help text

### DIFF
--- a/checksums.js
+++ b/checksums.js
@@ -29,13 +29,13 @@ function main() {
     program
         .description('Prints membership checksums')
         .option('--tchannel-v1')
-        .usage('[options] <address>');
+        .usage('[options] <hostport or bootstrapfile>');
     program.parse(process.argv);
 
     var address = program.args[0];
 
     if (!address) {
-        console.error('Error: hostport is required');
+        console.error('Error: hostport or bootstrapfile is required');
         process.exit(1);
     }
 

--- a/count.js
+++ b/count.js
@@ -31,13 +31,13 @@ function main() {
         .option('-m --members', 'Count of members')
         .option('-p --partitions', 'Count of partitions')
         .option('--tchannel-v1')
-        .usage('[options] <hostport>');
+        .usage('[options] <hostport or bootstrapfile>');
     program.parse(process.argv);
 
     var coord = program.args[0];
 
     if (!coord) {
-        console.error('Error: hostport is required');
+        console.error('Error: hostport or path to bootstrap file is required');
         process.exit(1);
     }
 

--- a/dist.js
+++ b/dist.js
@@ -37,7 +37,7 @@ function main() {
     var hostPort = program.args[0];
 
     if (!hostPort) {
-        console.error('hostport is required');
+        console.error('Error: hostport is required');
         process.exit(1);
     }
 

--- a/dump.js
+++ b/dump.js
@@ -30,13 +30,13 @@ function main() {
         .description('Dumps membership information to file')
         .option('-f --file <file>', 'File to dump to')
         .option('--tchannel-v1')
-        .usage('[options] <hostport>');
+        .usage('[options] <hostport or bootstrapfile>');
     program.parse(process.argv);
 
     var coord = program.args[0];
 
     if (!coord) {
-        console.error('Error: hostport is required');
+        console.error('Error: hostport or path to bootstrap file is required');
         process.exit(1);
     }
 

--- a/join.js
+++ b/join.js
@@ -29,13 +29,13 @@ function main() {
     program
         .description('Makes node (re)join cluster')
         .option('--tchannel-v1')
-        .usage('[options] <address>');
+        .usage('[options] <hostport>');
     program.parse(process.argv);
 
     var address = program.args[0];
 
     if (!address) {
-        console.error('Error: address is required');
+        console.error('Error: hostport is required');
         process.exit(1);
     }
 

--- a/leave.js
+++ b/leave.js
@@ -29,13 +29,13 @@ function main() {
     program
         .description('Makes node leave cluster')
         .option('--tchannel-v1')
-        .usage('[options] <address>');
+        .usage('[options] <hostport>');
     program.parse(process.argv);
 
     var address = program.args[0];
 
     if (!address) {
-        console.error('Error: address is required');
+        console.error('Error: hostport is required');
         process.exit(1);
     }
 

--- a/list.js
+++ b/list.js
@@ -30,13 +30,13 @@ function main() {
         .option('-h --hosts', 'List hosts')
         .option('-m --members', 'List members')
         .option('--tchannel-v1')
-        .usage('[options] <hostport>');
+        .usage('[options] <hostport or bootstrapfile>');
     program.parse(process.argv);
 
     var coord = program.args[0];
 
     if (!coord) {
-        console.error('Error: hostport is required');
+        console.error('Error: hostport or bootstrapfile is required');
         process.exit(1);
     }
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "ringpop-admin-list": "./list.js",
     "ringpop-admin-lookup": "./lookup.js",
     "ringpop-admin-join": "./join.js",
+    "ringpop-admin-partitions": "./partitions.js",
     "ringpop-admin-status": "./status.js",
     "ringpop-admin-top": "./top.js"
   },

--- a/parser.js
+++ b/parser.js
@@ -24,7 +24,7 @@ var program = require('commander');
 
 function assertPositionArg(program, pos, arg) {
     if (program.args[pos]) return;
-    console.error('Error: ' + arg + 'is required');
+    console.error('Error: ' + arg + ' is required');
     process.exit(1);
 }
 
@@ -34,9 +34,9 @@ function parseReuseCommand() {
         .option('-m, --member <memberAddr>, Address of member to reuse')
         .option('-l, --limit <limit>, Parallelism limit')
         .option('--tchannel-v1')
-        .usage('[options] <coordinator>');
+        .usage('[options] <hostport or bootstrapfile>');
     program.parse(process.argv);
-    assertPositionArg(program, 0, 'coordinator');
+    assertPositionArg(program, 0, 'hostport or bootstrapfile');
 
     return new commands.ReuseCommand(
         program.tchannelV1,
@@ -50,9 +50,9 @@ function parseStatusCommand() {
     program
         .description('Status of members in ring')
         .option('--tchannel-v1')
-        .usage('[options] <coordinator>');
+        .usage('[options] <hostport or bootstrapfile>');
     program.parse(process.argv);
-    assertPositionArg(program, 0, 'coordinator');
+    assertPositionArg(program, 0, 'hostport or bootstrapfile');
 
     return new commands.StatusCommand(program.tchannelV1, program.args[0]);
 }
@@ -62,9 +62,9 @@ function parsePartitionCommand() {
         .description('Show partition information of a ring')
         .option('--tchannel-v1')
         .option('-q, --quiet', 'Don\'t print headers')
-        .usage('[options] <coordinatorOrFile>');
+        .usage('[options] <hostport or bootstrapfile>');
     program.parse(process.argv);
-    assertPositionArg(program, 0, 'coordinatorOrFile');
+    assertPositionArg(program, 0, 'hostport or bootstrapfile');
 
     return new commands.PartitionCommand(
         program.tchannelV1,

--- a/top.js
+++ b/top.js
@@ -55,7 +55,7 @@ function main() {
         .option('-r, --refresh-rate <refresh-rate>', 'Refresh rate (in milliseconds). Default is 10000.')
         .option('-R, --no-refresh', 'Turn refresh off. top will exit immediately after first download.')
         .option('--tchannel-v1', 'Use TChannel v1. Default is v2.')
-        .usage('[options] <host-port>');
+        .usage('[options] <hostport or bootstrapfile>');
 
     program.on('--help', function onHelp() {
         console.log('  Key bindings: ');
@@ -75,7 +75,7 @@ function main() {
     var coordinatorAddress = program.args[0];
 
     if (!coordinatorAddress) {
-        console.error('host-port is required');
+        console.error('hostport or bootstrapfile is required');
         process.exit(1);
     }
 

--- a/top.js
+++ b/top.js
@@ -75,7 +75,7 @@ function main() {
     var coordinatorAddress = program.args[0];
 
     if (!coordinatorAddress) {
-        console.error('hostport or bootstrapfile is required');
+        console.error('Error: hostport or bootstrapfile is required');
         process.exit(1);
     }
 


### PR DESCRIPTION
* Tidy up `--help` in ringpop-admin to indicate that a bootstrap file can be passed (for those commands that support it).
* Be consistent with naming, e.g. "hostport" instead of "coordinator" (hostport is more informative to the operator).