### PR TITLE
Fix broken 'dist' command

### DIFF
--- a/dist.js
+++ b/dist.js
@@ -24,7 +24,7 @@
 var CliColor = require('cli-color');
 var AdminClient = require('./lib/admin-client.js');
 var createTable = require('./lib/table.js');
-var HashRing = require('ringpop/lib/ring.js');
+var HashRing = require('ringpop/lib/ring/index.js');
 var program = require('commander');
 
 function main() {


### PR DESCRIPTION
The `dist` command was previously broken due to a reorg of files in the ringpop library:

```
$ ringpop-admin dist 10.26.5.8:21152

module.js:340
    throw err;
          ^
Error: Cannot find module 'ringpop/lib/ring.js'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/usr/lib/node_modules/ringpop-admin/dist.js:27:16)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
```
