### PR TITLE
Expose errors when ringpop-admin cannot access members

### DIFF
--- a/count.js
+++ b/count.js
@@ -69,6 +69,11 @@ function main() {
 
         var cluster = clusterManager.getClusterAt(0);
 
+        if (!cluster) {
+            console.error('Error: no members in the cluster could be reached');
+            process.exit(1);
+        }
+
         if (program.members) {
             console.log(cluster.getNodeCount());
             process.exit();

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -138,7 +138,7 @@ Cluster.prototype.fetchStats = function fetchStats(callback) {
             statsObj.address = memberAddr;
 
             if (err) {
-                next(null, statsObj);
+                next(err, statsObj);
                 return;
             }
 

--- a/list.js
+++ b/list.js
@@ -62,6 +62,11 @@ function main() {
 
         var cluster = clusterManager.getClusterAt(0);
 
+        if (!cluster) {
+            console.error('Error: no members in the cluster could be reached');
+            process.exit(1);
+        }
+
         if (program.members) {
             printSorted(cluster.getMemberAddrs());
             process.exit();

--- a/status.js
+++ b/status.js
@@ -44,6 +44,10 @@ function main() {
 
         var table = createTable([]);
         var cluster = clusterManager.getClusterAt(0);
+        if (!cluster) {
+            console.error('Error: no members in the cluster could be reached');
+            process.exit(1);
+        }
         cluster.membership.forEach(function each(member) {
             table.push([member.address, member.status]);
         });


### PR DESCRIPTION
Previously, it would crash with no clues as to why (where `10.0.0.1:20700` is non-existent):

```
$ ringpop-admin list 10.0.0.1:20700 -m                                              

/usr/lib/node_modules/ringpop-admin/list.js:66
            printSorted(cluster.getMemberAddrs());
                                ^
TypeError: Cannot call method 'getMemberAddrs' of undefined
    at onStats (/usr/lib/node_modules/ringpop-admin/list.js:66:33)
    at onComplete (/usr/lib/node_modules/ringpop-admin/lib/cluster.js:184:9)
    at Object.fetchQueue.drain (/usr/lib/node_modules/ringpop-admin/lib/cluster.js:123:9)
    at next (/usr/lib/node_modules/ringpop-admin/node_modules/async/lib/async.js:801:31)
    at /usr/lib/node_modules/ringpop-admin/node_modules/async/lib/async.js:32:16
    at /usr/lib/node_modules/ringpop-admin/lib/cluster.js:141:17
    at onIdentified (/usr/lib/node_modules/ringpop-admin/lib/admin-client.js:118:13)
    at finish (/usr/lib/node_modules/ringpop-admin/node_modules/tchannel/peer.js:259:9)
    at Array.onConnectionClose [as 1] (/usr/lib/node_modules/ringpop-admin/node_modules/tchannel/peer.js:246:9)
    at DefinedEvent.emit (/usr/lib/node_modules/ringpop-admin/node_modules/tchannel/lib/event_emitter.js:90:25)
```

/cc @jwolski 