### PR TITLE
add error for when ringpop-admin cannot find any members

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -175,6 +175,10 @@ Cluster.prototype.fetchStats = function fetchStats(callback) {
     }
 
     function onComplete(err, allStats) {
+        if (allStats.length === 0) {
+            callback(new Error('Failed to connect to any ringpop members'));
+            return;
+        }
         self.lastDownloadTime = Date.now() - downloadTime;
         self.allStats = allStats;
         self.allStats.forEach(function eachStats(stats) {


### PR DESCRIPTION
ringpop-admin top no longer goes to fullscreen mode showing a cluster of 0 members. In stead it prints an error message. This also makes the tchannel error visible which, before, was cleared because of fullscreen mode.