### PR TITLE
Feature/discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,38 @@ Command-line tools for Ringpop
 
     -h, --help     output usage information
     -V, --version  output the version number
+
+  Discovery:
+
+    Most of the commands can discover the ring via
+    a discoverUri like this: 'ringpop://127.0.0.1:3000'.
+    If no protocol is specified 'ringpop://' will be
+    used.
+
+    Supported protocols are:
+
+     - ringpop://
+       Discover the ring by connecting to a host of
+       the ring.
+
+       Example: ringpop://127.0.0.1:3000
+
+     - file://
+       Discover the ring by reading a json file
+       containing an array of host:port combinations
+
+       Example: file:///absolute/path/to/file
+       Example: file://./relative/path
+       File content: ["127.0.0.1:3000"]
+
+     - hyperbahn://
+       Discover the ring by querying hyperbahn for
+       the members of a service. When no hyperbahn
+       ip and port are given 127.0.0.1:21300 will be
+       used.
+
+       Example: hyperbahn:///ringpop
+       Example: hyperbahn://hyperbahn-ip:port/ringpop
 ```
 
 ## Tests

--- a/checksums.js
+++ b/checksums.js
@@ -29,19 +29,19 @@ function main() {
     program
         .description('Prints membership checksums')
         .option('--tchannel-v1')
-        .usage('[options] <hostport or bootstrapfile>');
+        .usage('[options] <discoveryUri>');
     program.parse(process.argv);
 
-    var address = program.args[0];
+    var discoveryUri = program.args[0];
 
-    if (!address) {
-        console.error('Error: hostport or bootstrapfile is required');
+    if (!discoveryUri) {
+        console.error('Error: discoveryUri is required');
         process.exit(1);
     }
 
     var clusterManager = new ClusterManager({
         useTChannelV1: program.useTChannelV1,
-        coordAddr: address
+        discoveryUri: discoveryUri
     });
     clusterManager.fetchStats(function onStats(err) {
         if (err) {

--- a/commands.js
+++ b/commands.js
@@ -19,22 +19,22 @@
 // THE SOFTWARE.
 'use strict';
 
-function ReuseCommand(tchannelV1, coordinator, member, limit) {
+function ReuseCommand(tchannelV1, discoveryUri, member, limit) {
     this.useTChannelV1 = tchannelV1;
-    this.coordinator = coordinator;
+    this.discoveryUri = discoveryUri;
     this.member = member;
     this.limit = limit;
 }
 
-function StatusCommand(tchannelV1, coordinator, quiet) {
+function StatusCommand(tchannelV1, discoveryUri, quiet) {
     this.useTChannelV1 = tchannelV1;
-    this.coordinator = coordinator;
+    this.discoveryUri = discoveryUri;
     this.quiet = quiet;
 }
 
-function PartitionCommand(tchannelV1, coordinatorOrFile, quiet) {
+function PartitionCommand(tchannelV1, discoveryUri, quiet) {
     this.useTChannelV1 = tchannelV1;
-    this.coordinatorOrFile = coordinatorOrFile;
+    this.discoveryUri = discoveryUri;
     this.quiet = quiet;
 }
 

--- a/count.js
+++ b/count.js
@@ -31,13 +31,13 @@ function main() {
         .option('-m --members', 'Count of members')
         .option('-p --partitions', 'Count of partitions')
         .option('--tchannel-v1')
-        .usage('[options] <hostport or bootstrapfile>');
+        .usage('[options] <discoveryUri>');
     program.parse(process.argv);
 
-    var coord = program.args[0];
+    var discoveryUri = program.args[0];
 
-    if (!coord) {
-        console.error('Error: hostport or path to bootstrap file is required');
+    if (!discoveryUri) {
+        console.error('Error: discoveryUri is required');
         process.exit(1);
     }
 
@@ -48,7 +48,7 @@ function main() {
 
     var clusterManager = new ClusterManager({
         useTChannelV1: program.tchannelV1,
-        coordAddr: coord
+        discoveryUri: discoveryUri
     });
     clusterManager.fetchStats(function onStats(err) {
         if (err) {

--- a/dump.js
+++ b/dump.js
@@ -30,13 +30,13 @@ function main() {
         .description('Dumps membership information to file')
         .option('-f --file <file>', 'File to dump to')
         .option('--tchannel-v1')
-        .usage('[options] <hostport or bootstrapfile>');
+        .usage('[options] <discoveryUri>');
     program.parse(process.argv);
 
-    var coord = program.args[0];
+    var discoveryUri = program.args[0];
 
-    if (!coord) {
-        console.error('Error: hostport or path to bootstrap file is required');
+    if (!discoveryUri) {
+        console.error('Error: discovery discoveryUri is required');
         process.exit(1);
     }
 
@@ -47,7 +47,7 @@ function main() {
 
     var clusterManager = new ClusterManager({
         useTChannelV1: program.tchannelV1,
-        coordAddr: coord
+        discoveryUri: discoveryUri
     });
     clusterManager.fetchStats(onStats);
 

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -37,7 +37,7 @@ function Cluster(opts) {
     };
 
     this.useTChannelV1 = opts.useTChannelV1;
-    this.coordAddr = opts.coordAddr;
+    this.discoveryUri = opts.discoveryUri;
     this.adminClient = new AdminClient({
         useTChannelV1: this.useTChannelV1
     });
@@ -87,7 +87,7 @@ Cluster.prototype.getPartitionCount = function getPartitionCount() {
 
 Cluster.prototype.getSeedList = function getSeedList(callback) {
     // use the discover library to fetch the seedlist
-    discover(this.coordAddr, callback);
+    discover(this.discoveryUri, callback);
 };
 
 Cluster.prototype.fetchStats = function fetchStats(callback) {
@@ -161,7 +161,7 @@ Cluster.prototype.fetchStats = function fetchStats(callback) {
 
     function onComplete(err, allStats) {
         if (allStats.length === 0) {
-            var addr = self.coordAddr;
+            var addr = self.discoveryUri;
             var msg = format('Failed to connect to ringpop listening on %s.', addr);
 
             // Check if user tries to connect to localhost or 127.0.0.1.
@@ -203,13 +203,13 @@ Cluster.prototype.fetchStats = function fetchStats(callback) {
 
 Cluster.prototype.lookup = function lookup(key, callback) {
     var self = this;
-    this.fetchStats(function onStats(err) {
+
+    this.getSeedList(function (err, seeds) {
         if (err) {
             callback(err);
             return;
         }
-
-        self.adminClient.lookup(self.coordAddr, key, callback);
+        self.adminClient.lookup(seeds[0], key, callback);
     });
 };
 

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -108,9 +108,9 @@ Cluster.prototype.fetchStats = function fetchStats(callback) {
     };
 
     this.getSeedList(function (err, seeds) {
-        console.warn("seeds:", arguments);
         if (err) {
-            return callback(err);
+            callback(err);
+            return;
         }
         queueMembers(seeds);
     });

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -29,6 +29,8 @@ var Stats = require('./stats.js');
 var format = require('util').format;
 var startsWith = require('./util.js').startsWith;
 
+var discover = require('./discover').discover;
+
 function Cluster(opts) {
     opts = opts || {
         dumpTo: 'ringpop-admin-stats.dump'
@@ -84,29 +86,8 @@ Cluster.prototype.getPartitionCount = function getPartitionCount() {
 };
 
 Cluster.prototype.getSeedList = function getSeedList(callback) {
-    var self = this;
-    // figure out if the coordinator is a file
-    fs.exists(self.coordAddr, function (exists) {
-        if (exists) {
-            // treat the coordinator as a bootstrap file
-            fs.readFile(self.coordAddr, function (err, body) {
-                if (err) {
-                    return callback(err);
-                }
-
-                try {
-                    body = JSON.parse(body);
-                } catch (e) {
-                    return callback(e);
-                }
-
-                // seed the list with the hosts in the bootstrap file
-                return callback(null, body);
-            });
-        } else {
-            return callback(null, [self.coordAddr]);
-        }
-    });
+    // use the discover library to fetch the seedlist
+    discover(this.coordAddr, callback);
 };
 
 Cluster.prototype.fetchStats = function fetchStats(callback) {
@@ -127,6 +108,7 @@ Cluster.prototype.fetchStats = function fetchStats(callback) {
     };
 
     this.getSeedList(function (err, seeds) {
+        console.warn("seeds:", arguments);
         if (err) {
             return callback(err);
         }

--- a/lib/discover/file.js
+++ b/lib/discover/file.js
@@ -1,20 +1,23 @@
 var fs = require('fs');
 
-module.exports.discover = function fileDiscover(urlObj, original, callback) {
+module.exports.discover = function fileDiscover(urlObj, uri, callback) {
     var filename = urlObj.host + urlObj.pathname;
     fs.readFile(filename, function (err, data) {
         if (err) {
-            return callback(err);
+            callback(err);
+            return;
         }
 
         // assume the file is a json list of hosts
         try {
             data = JSON.parse(data);
         } catch (e) {
-            return callback(e);
+            callback(e);
+            return;
         }
 
         // TODO add type tests for the data read from the file
-        return callback(null, data);
+        callback(null, data);
+        return;
     });
 }

--- a/lib/discover/file.js
+++ b/lib/discover/file.js
@@ -1,0 +1,20 @@
+var fs = require('fs');
+
+module.exports.discover = function fileDiscover(urlObj, original, callback) {
+    var filename = urlObj.host + urlObj.pathname;
+    fs.readFile(filename, function (err, data) {
+        if (err) {
+            return callback(err);
+        }
+
+        // assume the file is a json list of hosts
+        try {
+            data = JSON.parse(data);
+        } catch (e) {
+            return callback(e);
+        }
+
+        // TODO add type tests for the data read from the file
+        return callback(null, data);
+    });
+}

--- a/lib/discover/file.js
+++ b/lib/discover/file.js
@@ -20,4 +20,4 @@ module.exports.discover = function fileDiscover(urlObj, uri, callback) {
         callback(null, data);
         return;
     });
-}
+};

--- a/lib/discover/hyperbahn.js
+++ b/lib/discover/hyperbahn.js
@@ -3,7 +3,7 @@ var TChannel = require('tchannel');
 var fs = require('fs');
 var path = require('path');
 
-module.exports.discover = function hyperbahnDiscover(urlObj, original, callback) {
+module.exports.discover = function hyperbahnDiscover(urlObj, uri, callback) {
     var host;
     if (urlObj.host) {
         host = urlObj.host;
@@ -31,6 +31,8 @@ module.exports.discover = function hyperbahnDiscover(urlObj, original, callback)
 
         tchannelAsThrift.request({
             host: host,
+            timeout: 5000,
+
             serviceName: 'hyperbahn',
             headers: {
                 cn: 'hyperbahn'
@@ -42,7 +44,8 @@ module.exports.discover = function hyperbahnDiscover(urlObj, original, callback)
             }
         }, function (err, resp) {
             if (err) {
-                return callback(err);
+                callback(err);
+                return;
             }
 
             // parse the hyperbahn response
@@ -51,19 +54,20 @@ module.exports.discover = function hyperbahnDiscover(urlObj, original, callback)
                 seeds = resp.body.peers.map(function(peer) {
                     switch (peer.ip.type) {
                         case 'ipv4':
-                            return [intToIP(peer.ip.ipv4), peer.port].join(':')
+                            return [intToIP(peer.ip.ipv4), peer.port].join(':');
                         default:
-                            throw new Error("Unknown ip type '" + peer.ip.type + "'")
+                            throw new Error('Hyperbahn returned peers with an invalid IP type: \'' + peer.ip.type + '\'');
                     }
                 });
             } catch (e) {
-                return callback(e);
+                callback(e);
+                return;
             }
 
-            return callback(null, seeds);
+            callback(null, seeds);
         });
     });
-}
+};
 
 function intToIP(int) {
     var part1 = int & 255;
@@ -72,4 +76,4 @@ function intToIP(int) {
     var part4 = ((int >> 24) & 255);
 
     return part4 + "." + part3 + "." + part2 + "." + part1;
-}
+};

--- a/lib/discover/hyperbahn.js
+++ b/lib/discover/hyperbahn.js
@@ -1,6 +1,5 @@
 var TChannelAsThrift = require('tchannel/as/thrift');
 var TChannel = require('tchannel');
-var fs = require('fs');
 var path = require('path');
 
 module.exports.discover = function hyperbahnDiscover(urlObj, uri, callback) {
@@ -76,4 +75,4 @@ function intToIP(int) {
     var part4 = ((int >> 24) & 255);
 
     return part4 + "." + part3 + "." + part2 + "." + part1;
-};
+}

--- a/lib/discover/hyperbahn.js
+++ b/lib/discover/hyperbahn.js
@@ -1,0 +1,3 @@
+module.exports.discover = function hyperbahnDiscover(urlObj, original, callback) {
+    return callback(new Error("Not implemented yet"));
+}

--- a/lib/discover/hyperbahn.js
+++ b/lib/discover/hyperbahn.js
@@ -1,3 +1,75 @@
+var TChannelAsThrift = require('tchannel/as/thrift');
+var TChannel = require('tchannel');
+var fs = require('fs');
+var path = require('path');
+
 module.exports.discover = function hyperbahnDiscover(urlObj, original, callback) {
-    return callback(new Error("Not implemented yet"));
+    var host;
+    if (urlObj.host) {
+        host = urlObj.host;
+    } else {
+        host = '127.0.0.1:21300';
+    }
+
+    var client = TChannel();
+    var hChannel = client.makeSubChannel({
+        serviceName: 'hyperbahn',
+        peers: [host]
+    });
+    var tchannelAsThrift = TChannelAsThrift({
+        channel: hChannel,
+        entryPoint: path.join(__dirname, 'hyperbahn.thrift')
+    });
+
+    tchannelAsThrift.waitForIdentified({
+        host: host
+    }, function onIdentified(err) {
+        if (err) {
+            callback(err);
+            return;
+        }
+
+        tchannelAsThrift.request({
+            host: host,
+            serviceName: 'hyperbahn',
+            headers: {
+                cn: 'hyperbahn'
+            },
+            hasNoParent: true
+        }).send('Hyperbahn::discover', {}, {
+            query: {
+                serviceName: urlObj.pathname.substr(1) // remove first slash
+            }
+        }, function (err, resp) {
+            if (err) {
+                return callback(err);
+            }
+
+            // parse the hyperbahn response
+            var seeds;
+            try {
+                seeds = resp.body.peers.map(function(peer) {
+                    switch (peer.ip.type) {
+                        case 'ipv4':
+                            return [intToIP(peer.ip.ipv4), peer.port].join(':')
+                        default:
+                            throw new Error("Unknown ip type '" + peer.ip.type + "'")
+                    }
+                });
+            } catch (e) {
+                return callback(e);
+            }
+
+            return callback(null, seeds);
+        });
+    });
+}
+
+function intToIP(int) {
+    var part1 = int & 255;
+    var part2 = ((int >> 8) & 255);
+    var part3 = ((int >> 16) & 255);
+    var part4 = ((int >> 24) & 255);
+
+    return part4 + "." + part3 + "." + part2 + "." + part1;
 }

--- a/lib/discover/hyperbahn.thrift
+++ b/lib/discover/hyperbahn.thrift
@@ -1,0 +1,35 @@
+exception NoPeersAvailable {
+    1: required string message
+    2: required string serviceName
+}
+
+exception InvalidServiceName {
+    1: required string message
+    2: required string serviceName
+}
+
+struct DiscoveryQuery {
+    1: required string serviceName
+}
+
+union IpAddress {
+  1: i32 ipv4
+}
+
+struct ServicePeer {
+  1: required IpAddress ip
+  2: required i32 port
+}
+
+struct DiscoveryResult {
+  1: required list<ServicePeer> peers
+}
+
+service Hyperbahn {
+    DiscoveryResult discover(
+        1: required DiscoveryQuery query
+    ) throws (
+        1: NoPeersAvailable noPeersAvailable
+        2: InvalidServiceName invalidServiceName
+    )
+}

--- a/lib/discover/index.js
+++ b/lib/discover/index.js
@@ -1,21 +1,20 @@
-var url = require('url')
+var url = require('url');
 
 module.exports.protocols = {
     "hyperbahn:": require('./hyperbahn').discover,
     "file:": require('./file').discover,
-    "ip:": require('./ip').discover,
-    // by default fallback on ip discovery
-    default: require('./ip').discover
-}
+    "ringpop:": require('./ringpop').discover,
+    // by default fallback on ringpop discovery
+    default: require('./ringpop').discover
+};
 
 // find a list of initial nodes to connect to based on the discover string
-module.exports.discover = function (discover, callback) {
-    var urlObj = url.parse(discover)
+module.exports.discover = function discover(uri, callback) {
+    var urlObj = url.parse(uri);
     var handler = module.exports.protocols[urlObj.protocol];
     if (typeof handler === 'undefined') {
         handler = module.exports.protocols.default;
     }
 
-    handler(urlObj, discover, callback);
-    return
-}
+    handler(urlObj, uri, callback);
+};

--- a/lib/discover/index.js
+++ b/lib/discover/index.js
@@ -12,7 +12,6 @@ module.exports.protocols = {
 module.exports.discover = function (discover, callback) {
     var urlObj = url.parse(discover)
     var handler = module.exports.protocols[urlObj.protocol];
-    console.warn("handler:", handler, "protocol:", urlObj.protocol)
     if (typeof handler === 'undefined') {
         handler = module.exports.protocols.default;
     }

--- a/lib/discover/index.js
+++ b/lib/discover/index.js
@@ -1,0 +1,22 @@
+var url = require('url')
+
+module.exports.protocols = {
+    "hyperbahn:": require('./hyperbahn').discover,
+    "file:": require('./file').discover,
+    "ip:": require('./ip').discover,
+    // by default fallback on ip discovery
+    default: require('./ip').discover
+}
+
+// find a list of initial nodes to connect to based on the discover string
+module.exports.discover = function (discover, callback) {
+    var urlObj = url.parse(discover)
+    var handler = module.exports.protocols[urlObj.protocol];
+    console.warn("handler:", handler, "protocol:", urlObj.protocol)
+    if (typeof handler === 'undefined') {
+        handler = module.exports.protocols.default;
+    }
+
+    handler(urlObj, discover, callback);
+    return
+}

--- a/lib/discover/ip.js
+++ b/lib/discover/ip.js
@@ -1,7 +1,0 @@
-module.exports.discover = function ipDiscover(urlObj, original, callback) {
-    if (urlObj.protocol === 'ip:') {
-        return setImmediate(callback, null, [urlObj.host])
-    } else {
-        return setImmediate(callback, null, [original])
-    }
-}

--- a/lib/discover/ip.js
+++ b/lib/discover/ip.js
@@ -1,0 +1,7 @@
+module.exports.discover = function ipDiscover(urlObj, original, callback) {
+    if (urlObj.protocol === 'ip:') {
+        return setImmediate(callback, null, [urlObj.host])
+    } else {
+        return setImmediate(callback, null, [original])
+    }
+}

--- a/lib/discover/ringpop.js
+++ b/lib/discover/ringpop.js
@@ -2,9 +2,16 @@ module.exports.discover = function ringpopDiscover(urlObj, uri, callback) {
     // TODO actually get a seedlist by querying ringpop
 
     // Check if ringpop discovery is used via a url or as a fallback
+    var host;
     if (urlObj.protocol === 'ringpop:') {
-        return setImmediate(callback, null, [urlObj.host]);
+        host = urlObj.host;
     } else {
-        return setImmediate(callback, null, [uri]);
+        host = uri;
     }
+
+    if (!host.match(/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d+/)) {
+        return setImmediate(callback, new Error("Expected an ip:port, hostnames are not allowed."));
+    }
+
+    return setImmediate(callback, null, [host]);
 };

--- a/lib/discover/ringpop.js
+++ b/lib/discover/ringpop.js
@@ -1,0 +1,10 @@
+module.exports.discover = function ringpopDiscover(urlObj, uri, callback) {
+    // TODO actually get a seedlist by querying ringpop
+
+    // Check if ringpop discovery is used via a url or as a fallback
+    if (urlObj.protocol === 'ringpop:') {
+        return setImmediate(callback, null, [urlObj.host]);
+    } else {
+        return setImmediate(callback, null, [uri]);
+    }
+};

--- a/list.js
+++ b/list.js
@@ -30,13 +30,13 @@ function main() {
         .option('-h --hosts', 'List hosts')
         .option('-m --members', 'List members')
         .option('--tchannel-v1')
-        .usage('[options] <hostport or bootstrapfile>');
+        .usage('[options] <discoveryUri>');
     program.parse(process.argv);
 
-    var coord = program.args[0];
+    var discoveryUri = program.args[0];
 
-    if (!coord) {
-        console.error('Error: hostport or bootstrapfile is required');
+    if (!discoveryUri) {
+        console.error('Error: discoveryUri is required');
         process.exit(1);
     }
 
@@ -47,7 +47,7 @@ function main() {
 
     var clusterManager = new ClusterManager({
         useTChannelV1: program.tchannelV1,
-        coordAddr: coord
+        discoveryUri: discoveryUri
     });
     clusterManager.fetchStats(function onStats(err) {
         if (err) {

--- a/lookup.js
+++ b/lookup.js
@@ -29,13 +29,13 @@ function main() {
         .description('Lookup a key in the ring')
         .option('-k --key <key>', 'Key to lookup')
         .option('--tchannel-v1')
-        .usage('[options] <hostport>');
+        .usage('[options] <discoveryUri>');
     program.parse(process.argv);
 
-    var coord = program.args[0];
+    var discoveryUri = program.args[0];
 
-    if (!coord) {
-        console.error('Error: hostport is required');
+    if (!discoveryUri) {
+        console.error('Error: discoveryUri is required');
         process.exit(1);
     }
 
@@ -46,7 +46,7 @@ function main() {
 
     var clusterManager = new ClusterManager({
         useTChannelV1: program.tchannelV1,
-        coordAddr: coord
+        discoveryUri: discoveryUri
     });
     clusterManager.lookup(program.key, function onLookup(err, res) {
         if (err) {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "cli-table": "^0.3.1",
     "commander": "^2.6.0",
     "ringpop": "^10.0.0",
-    "tchannel": "2.7.4",
+    "tchannel": "3.6.2",
     "underscore": "^1.8.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "ringpop-admin-top": "./top.js"
   },
   "scripts": {
-    "jshint": "jshint --verbose *.js lib/*.js",
+    "jshint": "jshint --verbose *.js lib/*.js lib/discover/*.js",
     "tchannel-v1": "mv node_modules/tchannel node_modules/tchannelv2 && npm install tchannel@1.3.2 && mv node_modules/tchannel node_modules/tchannelv1 && mv node_modules/tchannelv2 node_modules/tchannel",
     "test": "cd tests && ./run-tests"
   },

--- a/parser.js
+++ b/parser.js
@@ -34,9 +34,9 @@ function parseReuseCommand() {
         .option('-m, --member <memberAddr>, Address of member to reuse')
         .option('-l, --limit <limit>, Parallelism limit')
         .option('--tchannel-v1')
-        .usage('[options] <hostport or bootstrapfile>');
+        .usage('[options] <discoveryUri>');
     program.parse(process.argv);
-    assertPositionArg(program, 0, 'hostport or bootstrapfile');
+    assertPositionArg(program, 0, 'discoveryUri');
 
     return new commands.ReuseCommand(
         program.tchannelV1,
@@ -51,9 +51,9 @@ function parseStatusCommand() {
         .description('Status of members in ring')
         .option('-q, --quiet', 'Do not print headers')
         .option('--tchannel-v1')
-        .usage('[options] <hostport or bootstrapfile>');
+        .usage('[options] <discoveryUri>');
     program.parse(process.argv);
-    assertPositionArg(program, 0, 'hostport or bootstrapfile');
+    assertPositionArg(program, 0, 'discoveryUri');
 
     return new commands.StatusCommand(
         program.tchannelV1,
@@ -66,9 +66,9 @@ function parsePartitionCommand() {
         .description('Show partition information of a ring')
         .option('--tchannel-v1')
         .option('-q, --quiet', 'Don\'t print headers')
-        .usage('[options] <hostport or bootstrapfile>');
+        .usage('[options] <discoveryUri>');
     program.parse(process.argv);
-    assertPositionArg(program, 0, 'hostport or bootstrapfile');
+    assertPositionArg(program, 0, 'discoveryUri');
 
     return new commands.PartitionCommand(
         program.tchannelV1,

--- a/partitions.js
+++ b/partitions.js
@@ -29,7 +29,7 @@ function main() {
     var command = parsePartitionCommand();
     var clusterManager = new ClusterManager({
         useTChannelV1: command.useTChannelV1,
-        coordAddr: command.coordinatorOrFile
+        discoveryUri: command.discoveryUri
     });
 
     clusterManager.fetchStats(function onStats(err) {
@@ -56,7 +56,7 @@ function main() {
         partitions.forEach(function each(partition) {
             table.push([
                 partition.membershipChecksum,
-                partition.nodeCount, 
+                partition.nodeCount,
                 partition.aliveCount,
                 partition.suspectCount,
                 partition.faultyCount,

--- a/ringpop-admin.js
+++ b/ringpop-admin.js
@@ -38,6 +38,40 @@ function main() {
         .command('status', 'Status of members in ring')
         .command('partitions', 'Show partition information of a ring')
         .command('top', 'General membership information')
+        .on('--help', function onHelp() {
+            console.log('  Discovery:');
+            console.log('');
+            console.log('    Most of the commands can discover the ring via');
+            console.log('    a discoverUri like this: \'ringpop://127.0.0.1:3000\'.');
+            console.log('    If no protocol is specified \'ringpop://\' will be');
+            console.log('    used.');
+            console.log('');
+            console.log('    Supported protocols are:');
+            console.log('');
+            console.log('     - ringpop://');
+            console.log('       Discover the ring by connecting to a host of');
+            console.log('       the ring.');
+            console.log('');
+            console.log('       Example: ringpop://127.0.0.1:3000');
+            console.log('');
+            console.log('     - file://');
+            console.log('       Discover the ring by reading a json file');
+            console.log('       containing an array of host:port combinations');
+            console.log('');
+            console.log('       Example: file:///absolute/path/to/file');
+            console.log('       Example: file://./relative/path');
+            console.log('       File content: ["127.0.0.1:3000"]');
+            console.log('');
+            console.log('     - hyperbahn://');
+            console.log('       Discover the ring by querying hyperbahn for');
+            console.log('       the members of a service. When no hyperbahn');
+            console.log('       ip and port are given 127.0.0.1:21300 will be');
+            console.log('       used.');
+            console.log('');
+            console.log('       Example: hyperbahn:///ringpop');
+            console.log('       Example: hyperbahn://hyperbahn-ip:port/ringpop');
+            console.log('');
+        })
         .parse(process.argv);
 }
 

--- a/status.js
+++ b/status.js
@@ -56,7 +56,7 @@ function main() {
     var command = parseStatusCommand();
     var cluster = new Cluster({
         useTChannelV1: command.useTChannelV1,
-        coordAddr: command.coordinator
+        discoveryUri: command.discoveryUri
     });
     cluster.fetchStats(function onStats(err) {
         assertTruthy(!err, (err && err.message));

--- a/tests/checksum.t
+++ b/tests/checksum.t
@@ -9,7 +9,7 @@ Test checksum success:
 
 With bootstrap file option:
 
-  $  ringpop-admin checksums $TESTDIR/hosts.json
+  $  ringpop-admin checksums file://$TESTDIR/hosts.json
    127.0.0.1:3000   *  (glob)
    127.0.0.1:3001   *  (glob)
    127.0.0.1:3002   *  (glob)
@@ -19,19 +19,6 @@ With bootstrap file option:
 Invalid bootstrap file
 
   $  ringpop-admin checksums QWERTY
-  
-  assert.js:* (glob)
-    throw new assert.AssertionError({
-          ^
-  AssertionError: invalid destination
-      at TChannelPeer.makeOutSocket * (glob)
-      at TChannelPeer.connect * (glob)
-      at TChannelPeer.waitForIdentified * (glob)
-      at TChannel.waitForIdentified * (glob)
-      at AdminClient.requestV2 * (glob)
-      at AdminClient.request * (glob)
-      at AdminClient.stats * (glob)
-      at mapMember * (glob)
-      at Object.q.process [as _onImmediate] * (glob)
-      at processImmediate [as _immediateCallback] * (glob)
-  [8]
+  Error: Expected an ip:port, hostnames are not allowed.
+  [1]
+

--- a/tests/checksum.t
+++ b/tests/checksum.t
@@ -7,6 +7,15 @@ Test checksum success:
    127.0.0.1:3003   *  (glob)
    127.0.0.1:3004   *  (glob)
 
+With explicit ringpop:
+
+  $  ringpop-admin checksums ringpop://127.0.0.1:3000
+   127.0.0.1:3000   *  (glob)
+   127.0.0.1:3001   *  (glob)
+   127.0.0.1:3002   *  (glob)
+   127.0.0.1:3003   *  (glob)
+   127.0.0.1:3004   *  (glob)
+
 With bootstrap file option:
 
   $  ringpop-admin checksums file://$TESTDIR/hosts.json

--- a/tests/count.t
+++ b/tests/count.t
@@ -9,9 +9,9 @@ Test count success:
 
 With bootstrap file:
 
-  $  ringpop-admin count -m $TESTDIR/hosts.json
+  $  ringpop-admin count -m file://$TESTDIR/hosts.json
   5
-  $  ringpop-admin count -h $TESTDIR/hosts.json
+  $  ringpop-admin count -h file://$TESTDIR/hosts.json
   1
-  $  ringpop-admin count -p $TESTDIR/hosts.json
+  $  ringpop-admin count -p file://$TESTDIR/hosts.json
   1

--- a/tests/count.t
+++ b/tests/count.t
@@ -7,6 +7,15 @@ Test count success:
   $  ringpop-admin count -p 127.0.0.1:3000
   1
 
+With explicit ringpop:
+
+  $  ringpop-admin count -m ringpop://127.0.0.1:3000
+  5
+  $  ringpop-admin count -h ringpop://127.0.0.1:3000
+  1
+  $  ringpop-admin count -p ringpop://127.0.0.1:3000
+  1
+
 With bootstrap file:
 
   $  ringpop-admin count -m file://$TESTDIR/hosts.json

--- a/tests/dump.t
+++ b/tests/dump.t
@@ -1,6 +1,6 @@
 Dump command dumps file successfully:
 
-  $  ringpop-admin dump $TESTDIR/hosts.json -f /tmp/ringpop-admin-dump-test.json
+  $  ringpop-admin dump file://$TESTDIR/hosts.json -f /tmp/ringpop-admin-dump-test.json
 
 Check for non-zero file:
 

--- a/tests/list.t
+++ b/tests/list.t
@@ -9,6 +9,17 @@ Test list command success:
   127.0.0.1:3003
   127.0.0.1:3004
 
+With explicit ringpop:
+
+  $  ringpop-admin list -h ringpop://127.0.0.1:3000
+  127.0.0.1
+  $  ringpop-admin list -m ringpop://127.0.0.1:3000
+  127.0.0.1:3000
+  127.0.0.1:3001
+  127.0.0.1:3002
+  127.0.0.1:3003
+  127.0.0.1:3004
+
 With bootstrap file:
 
   $  ringpop-admin list -h file://$TESTDIR/hosts.json

--- a/tests/list.t
+++ b/tests/list.t
@@ -11,9 +11,9 @@ Test list command success:
 
 With bootstrap file:
 
-  $  ringpop-admin list -h $TESTDIR/hosts.json
+  $  ringpop-admin list -h file://$TESTDIR/hosts.json
   127.0.0.1
-  $  ringpop-admin list -m $TESTDIR/hosts.json
+  $  ringpop-admin list -m file://$TESTDIR/hosts.json
   127.0.0.1:3000
   127.0.0.1:3001
   127.0.0.1:3002

--- a/tests/lookup.t
+++ b/tests/lookup.t
@@ -1,0 +1,4 @@
+Test lookup success:
+
+  $  ringpop-admin lookup --key hello 127.0.0.1:3000
+  127.0.0.1:3004

--- a/tests/partitions.t
+++ b/tests/partitions.t
@@ -4,13 +4,17 @@ Partitions command success:
    Checksum*# Nodes*# Alive*# Suspect*# Faulty*Sample Host* (glob)
    *5*5*0*0*127.0.0.1:3000* (glob)
 
+With explicit ringpop:
+
+  $  ringpop-admin partitions ringpop://127.0.0.1:3000
+   Checksum*# Nodes*# Alive*# Suspect*# Faulty*Sample Host* (glob)
+   *5*5*0*0*127.0.0.1:3000* (glob)
 
 With bootstrap file:
 
   $  ringpop-admin partitions file://$TESTDIR/hosts.json
    Checksum*# Nodes*# Alive*# Suspect*# Faulty*Sample Host* (glob)
    *5*5*0*0*127.0.0.1:* (glob)
-
 
 Unable to connect to host:
 

--- a/tests/partitions.t
+++ b/tests/partitions.t
@@ -7,7 +7,7 @@ Partitions command success:
 
 With bootstrap file:
 
-  $  ringpop-admin partitions $TESTDIR/hosts.json
+  $  ringpop-admin partitions file://$TESTDIR/hosts.json
    Checksum*# Nodes*# Alive*# Suspect*# Faulty*Sample Host* (glob)
    *5*5*0*0*127.0.0.1:* (glob)
 
@@ -54,19 +54,5 @@ Provide hint if the user tries and fails to connect to localhost or 127.0.0.1
   [1]
 
   $  ringpop-admin partitions localhost:2999
-  Error while fetching node stats: { [TchannelSocketError: tchannel socket error (ECONNREFUSED from connect): connect ECONNREFUSED]
-    type: 'tchannel.socket',
-    message: 'tchannel socket error (ECONNREFUSED from connect): connect ECONNREFUSED',
-    hostPort: null,
-    direction: 'out',
-    remoteAddr: null,
-    name: 'TchannelSocketError',
-    socketRemoteAddr: 'localhost:2999',
-    causeMessage: 'connect ECONNREFUSED',
-    origMessage: 'connect ECONNREFUSED',
-    code: 'ECONNREFUSED',
-    errno: 'ECONNREFUSED',
-    syscall: 'connect',
-    fullType: 'tchannel.socket~!~error.wrapped-io.connect.ECONNREFUSED' }
-  Error: Failed to connect to ringpop listening on localhost:2999. Ringpop ordinarily does not listen on the loopback interface. Try a different IP address.
+  Error: Expected an ip:port, hostnames are not allowed.
   [1]

--- a/tests/ringpop-admin.t
+++ b/tests/ringpop-admin.t
@@ -33,3 +33,35 @@ Help:
       -h, --help     output usage information
       -V, --version  output the version number
   
+    Discovery:
+  
+      Most of the commands can discover the ring via
+      a discoverUri like this: 'ringpop://127.0.0.1:3000'.
+      If no protocol is specified 'ringpop://' will be
+      used.
+  
+      Supported protocols are:
+  
+       - ringpop://
+         Discover the ring by connecting to a host of
+         the ring.
+  
+         Example: ringpop://127.0.0.1:3000
+  
+       - file://
+         Discover the ring by reading a json file
+         containing an array of host:port combinations
+  
+         Example: file:///absolute/path/to/file
+         Example: file://./relative/path
+         File content: ["127.0.0.1:3000"]
+  
+       - hyperbahn://
+         Discover the ring by querying hyperbahn for
+         the members of a service. When no hyperbahn
+         ip and port are given 127.0.0.1:21300 will be
+         used.
+  
+         Example: hyperbahn:///ringpop
+         Example: hyperbahn://hyperbahn-ip:port/ringpop
+  

--- a/tests/top.t
+++ b/tests/top.t
@@ -16,6 +16,24 @@ Top command success:
    127.0.0.1:3004   alive 
    1 of 5
 
+With explicit ringpop:
+
+  $  ringpop-admin top -R ringpop://127.0.0.1:3000
+  \x1bcA cluster of 5 nodes have converged on a single membership view. (esc)
+  It took *ms to report the stats below. (glob)
+  
+  Last fetch: ????-??-??T??:??:??.???? (10s) (glob)
+  
+  \x1b[107m\x1b[32m   All   \x1b[39m\x1b[49m\x1b[47m\x1b[30m   P1   \x1b[39m\x1b[49m (esc)
+  
+   Address          P1    
+   \x1b[36m127.0.0.1:3000\x1b[39m   \x1b[36malive\x1b[39m  (esc)
+   127.0.0.1:3001   alive 
+   127.0.0.1:3002   alive 
+   127.0.0.1:3003   alive 
+   127.0.0.1:3004   alive 
+   1 of 5
+
 With bootstrap file:
 
   $  ringpop-admin top -R file://$TESTDIR/hosts.json

--- a/tests/top.t
+++ b/tests/top.t
@@ -18,7 +18,7 @@ Top command success:
 
 With bootstrap file:
 
-  $  ringpop-admin top -R $TESTDIR/hosts.json
+  $  ringpop-admin top -R file://$TESTDIR/hosts.json
   \x1bcA cluster of 5 nodes have converged on a single membership view. (esc)
   It took *ms to report the stats below. (glob)
   

--- a/top.js
+++ b/top.js
@@ -55,7 +55,7 @@ function main() {
         .option('-r, --refresh-rate <refresh-rate>', 'Refresh rate (in milliseconds). Default is 10000.')
         .option('-R, --no-refresh', 'Turn refresh off. top will exit immediately after first download.')
         .option('--tchannel-v1', 'Use TChannel v1. Default is v2.')
-        .usage('[options] <hostport or bootstrapfile>');
+        .usage('[options] <discoveryUri>');
 
     program.on('--help', function onHelp() {
         console.log('  Key bindings: ');
@@ -72,10 +72,10 @@ function main() {
 
     program.parse(process.argv);
 
-    var coordinatorAddress = program.args[0];
+    var discoveryUri = program.args[0];
 
-    if (!coordinatorAddress) {
-        console.error('Error: hostport or bootstrapfile is required');
+    if (!discoveryUri) {
+        console.error('Error: discoveryUri is required');
         process.exit(1);
     }
 
@@ -83,7 +83,7 @@ function main() {
     refreshRate = +program.refreshRate || Defaults.RefreshRate;
 
     var clusterManager = new ClusterManager({
-        coordAddr: coordinatorAddress,
+        discoveryUri: discoveryUri,
         dumpTo: program.dumpFile,
         useTChannelV1: program.tchannelV1
     });


### PR DESCRIPTION
add support for hyperbahn 'discovery' to `ringpop-admin`.

In the past you needed to know a `host:port` combination of a running ringpop instance to use `ringpop-admin` on the cluster. Later host file support has been added by checking if the `host:port` passed to the application existed as a file.

Now with `port 0` support for ringpop in `ringpop-go` both solutions are not scalable anymore. In the `port 0` world there will be no hosts file that you can use, and to find an alive node every time you want to get insights in the ring is too hard.

With this PR we will add more pluggable discovery support for a running cluster by letting the user specify a url to your cluster. The following protocols are supported:

 - `ip`: This is the old mechanism of providing a `host:port` combination to `ringpop-admin`. Example: `$ ringpop-admin top ip://127.0.0.1:3000`
 - `file`: This is a formalization of the previously added file support. Instead of magically testing if the provided argument is an existing file you now need to specify you want to discover your cluster from the hosts file. Example: `$ ringpop-admin top file://./hosts.json`
 - `hyperbahn`: In a `port 0` world nodes advertise with `hyperbahn`. Ringpop bootstrapping is now able to find running nodes from hyperbahn and bootstraps from there. This allows tchannel to not use a specific port to listen on and in a container world applications can move easily from host to host. This makes it harder to use `ringpop-admin` to get an insight in the cluster since there are no static locations of the nodes, and there is no hosts file. The hyperbahn discovery queries hyperbahn for a named service and uses the response list to figure out which nodes are there. Example `$ ringpop-admin top hyperbahn://127.0.0.1:21300/ringpopd-go`. If the `host:port` in the hyperbahn url is omitted it assumes `127.0.0.1:21300` as your local `hyperbahn` router.

If no protocol is provided it assumes it is the old `host:port` format, and uses the `ip` discover module.