### PR TITLE
Fix leave and join to use non-deprecated endpoint

### DIFF
--- a/lib/admin-client.js
+++ b/lib/admin-client.js
@@ -41,11 +41,11 @@ AdminClient.prototype.destroy = function destroy() {
 };
 
 AdminClient.prototype.join = function join(host, callback) {
-    this.request(host, '/admin/join', null, null, callback);
+    this.request(host, '/admin/member/join', null, null, callback);
 };
 
 AdminClient.prototype.leave = function leave(host, callback) {
-    this.request(host, '/admin/leave', null, null, callback);
+    this.request(host, '/admin/member/leave', null, null, callback);
 };
 
 AdminClient.prototype.lookup = function lookup(host, key, callback) {


### PR DESCRIPTION
`ringpop-admin` `leave` and `join` were calling deprecated endpoints that were only available in `ringpop-node` and not in `ringpop-go`. This PR is to update the endpoint to call.