### PR TITLE
Fix installation of cram on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
 before_script:
 # Install cram without sudo. This allows us to use Travis containers
 # which are *much* faster than using sudo: yes.
-- "pip install --target=/tmp cram"
+- "pip install --target=/tmp 'cram==0.6'"
 - "mv /tmp/cram.py /tmp/cram"
 - "chmod +x /tmp/cram"
 - export PATH=$PATH:/tmp


### PR DESCRIPTION
Recent CI started failing on `ringpop-admin` because a newer version of cram came without `cram.py` installed via `pip`. This PR forces travis to install `cram` 0.6.