### PR TITLE
Implement ringpop-admin-reap to reap faulty nodes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Command-line tools for Ringpop
     status       Status of members in ring
     partitions   Show partition information of a ring
     top          General membership information
-    reap         Remove the faulty nodes from this nodes membership
+    reap         Remove the faulty nodes from this node's membership
     help [cmd]   display help for [cmd]
 
   Command-line tools for Ringpop

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Command-line tools for Ringpop
     status       Status of members in ring
     partitions   Show partition information of a ring
     top          General membership information
+    reap         Remove the faulty nodes from this nodes membership
     help [cmd]   display help for [cmd]
 
   Command-line tools for Ringpop

--- a/lib/admin-client.js
+++ b/lib/admin-client.js
@@ -48,6 +48,10 @@ AdminClient.prototype.leave = function leave(host, callback) {
     this.request(host, '/admin/member/leave', null, null, callback);
 };
 
+AdminClient.prototype.reap = function reap(host, callback) {
+    this.request(host, '/admin/reap', null, null, callback);
+};
+
 AdminClient.prototype.lookup = function lookup(host, key, callback) {
     this.request(host, '/admin/lookup', null, JSON.stringify({
         key: key

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -221,6 +221,18 @@ Cluster.prototype.lookup = function lookup(key, callback) {
     });
 };
 
+Cluster.prototype.reap = function reap(callback) {
+    var self = this;
+
+    this.getSeedList(function (err, seeds) {
+        if (err) {
+            callback(err);
+            return;
+        }
+        self.adminClient.reap(seeds[0], callback);
+    });
+};
+
 Cluster.prototype.parseStats = function parseStats(stats) {
     if (!stats.membershipChecksum) {
         return;

--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
     "ringpop-admin-count": "./count.js",
     "ringpop-admin-dist": "./dist.js",
     "ringpop-admin-dump": "./dump.js",
+    "ringpop-admin-join": "./join.js",
     "ringpop-admin-leave": "./leave.js",
     "ringpop-admin-list": "./list.js",
     "ringpop-admin-lookup": "./lookup.js",
-    "ringpop-admin-join": "./join.js",
     "ringpop-admin-partitions": "./partitions.js",
+    "ringpop-admin-reap": "./reap.js",
     "ringpop-admin-status": "./status.js",
     "ringpop-admin-top": "./top.js"
   },

--- a/reap.js
+++ b/reap.js
@@ -27,7 +27,7 @@ var program = require('commander');
 
 function main() {
     program
-        .description('Remove the faulty nodes from this nodes membership')
+        .description('Remove the faulty nodes from this node\'s membership')
         .option('--tchannel-v1')
         .usage('[options] <discoveryUri>');
     program.parse(process.argv);

--- a/reap.js
+++ b/reap.js
@@ -27,7 +27,7 @@ var program = require('commander');
 
 function main() {
     program
-        .description('Remove the faulty nodes from this node\'s membership')
+        .description('Remove nodes marked as faulty from the cluster')
         .option('--tchannel-v1')
         .usage('[options] <discoveryUri>');
     program.parse(process.argv);

--- a/reap.js
+++ b/reap.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var ClusterManager = require('./lib/cluster.js');
+var assertNoError = require('./lib/util.js').assertNoError;
+var program = require('commander');
+
+function main() {
+    program
+        .description('Remove the faulty nodes from this nodes membership')
+        .option('--tchannel-v1')
+        .usage('[options] <discoveryUri>');
+    program.parse(process.argv);
+
+    var discoveryUri = program.args[0];
+
+    if (!discoveryUri) {
+        console.error('Error: discoveryUri is required');
+        process.exit(1);
+    }
+
+    var clusterManager = new ClusterManager({
+        useTChannelV1: program.tchannelV1,
+        discoveryUri: discoveryUri
+    });
+
+    clusterManager.reap(function onReap(err) {
+        assertNoError(err);
+        process.exit();
+    });
+}
+
+if (require.main === module) {
+    main();
+}

--- a/ringpop-admin.js
+++ b/ringpop-admin.js
@@ -38,7 +38,7 @@ function main() {
         .command('status', 'Status of members in ring')
         .command('partitions', 'Show partition information of a ring')
         .command('top', 'General membership information')
-        .command('reap', 'Remove the faulty nodes from this nodes membership')
+        .command('reap', 'Remove the faulty nodes from this node\'s membership')
         .on('--help', function onHelp() {
             console.log('  Discovery:');
             console.log('');

--- a/ringpop-admin.js
+++ b/ringpop-admin.js
@@ -38,6 +38,7 @@ function main() {
         .command('status', 'Status of members in ring')
         .command('partitions', 'Show partition information of a ring')
         .command('top', 'General membership information')
+        .command('reap', 'Remove the faulty nodes from this nodes membership')
         .on('--help', function onHelp() {
             console.log('  Discovery:');
             console.log('');

--- a/ringpop-admin.js
+++ b/ringpop-admin.js
@@ -38,7 +38,7 @@ function main() {
         .command('status', 'Status of members in ring')
         .command('partitions', 'Show partition information of a ring')
         .command('top', 'General membership information')
-        .command('reap', 'Remove the faulty nodes from this node\'s membership')
+        .command('reap', 'Remove nodes marked as faulty from the cluster')
         .on('--help', function onHelp() {
             console.log('  Discovery:');
             console.log('');

--- a/tests/reap.t
+++ b/tests/reap.t
@@ -1,0 +1,5 @@
+Test ringpop-admin reap on unsupported ringpop:
+
+  $  ringpop-admin reap 127.0.0.1:3000
+  Error: no such endpoint service="ringpop" endpoint="/admin/reap"
+  [1]

--- a/tests/ringpop-admin.t
+++ b/tests/ringpop-admin.t
@@ -24,7 +24,7 @@ Help:
       status       Status of members in ring
       partitions   Show partition information of a ring
       top          General membership information
-      reap         Remove the faulty nodes from this node's membership
+      reap         Remove nodes marked as faulty from the cluster
       help [cmd]   display help for [cmd]
   
     Command-line tools for Ringpop

--- a/tests/ringpop-admin.t
+++ b/tests/ringpop-admin.t
@@ -24,7 +24,7 @@ Help:
       status       Status of members in ring
       partitions   Show partition information of a ring
       top          General membership information
-      reap         Remove the faulty nodes from this nodes membership
+      reap         Remove the faulty nodes from this node's membership
       help [cmd]   display help for [cmd]
   
     Command-line tools for Ringpop

--- a/tests/ringpop-admin.t
+++ b/tests/ringpop-admin.t
@@ -24,6 +24,7 @@ Help:
       status       Status of members in ring
       partitions   Show partition information of a ring
       top          General membership information
+      reap         Remove the faulty nodes from this nodes membership
       help [cmd]   display help for [cmd]
   
     Command-line tools for Ringpop


### PR DESCRIPTION
This PR add an extra command to `ringpop-admin` which can be used to manually reap all the faulty nodes from a running ringpop cluster. This operation is non destructive as faulty nodes are not part of the ring used for sharding.