### PR TITLE
Expect working endpoints for heal and reap

### DIFF
--- a/tests/heal.t
+++ b/tests/heal.t
@@ -1,5 +1,4 @@
-Test ringpop-admin heal on unsupported ringpop:
+Test ringpop-admin heal:
 
   $  ringpop-admin heal 127.0.0.1:3000
-  Error: no such endpoint service="ringpop" endpoint="/admin/healpartition/disco"
-  [1]
+  [0-9:\.]+ No known partitions left (re)

--- a/tests/reap.t
+++ b/tests/reap.t
@@ -1,5 +1,4 @@
-Test ringpop-admin reap on unsupported ringpop:
+Test ringpop-admin reap:
 
   $  ringpop-admin reap 127.0.0.1:3000
-  Error: no such endpoint service="ringpop" endpoint="/admin/reap"
-  [1]
+


### PR DESCRIPTION
Since version 10.15, ringpop-node now supports healing and reaping; updating the tests to reflect those changes.