### PR TITLE
deps: bump farmhash, ring pop and tchannel

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "cli-color": "^1.0.0",
     "cli-table": "^0.3.1",
     "commander": "^2.6.0",
-    "farmhash": "^1.1.1",
-    "ringpop": "^10.0.0",
-    "tchannel": "3.6.2",
+    "farmhash": "^1.2.1",
+    "ringpop": "^10.18.0",
+    "tchannel": "3.9.9",
     "underscore": "^1.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
the farmhash build fails on node v6. this version is required
for the build to complete